### PR TITLE
Fix broken employees controller tests and Add tests for sessions controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'sessions#login', as: 'login'
 
   get 'auth/github', as: 'github_auth'
-  get 'auth/:provider/callback', to: 'sessions#create'
+  get 'auth/:provider/callback', to: 'sessions#create', as: 'omniauth_callback'
 
   # For details on the DSL available within this file,
   # see http://guides.rubyonrails.org/routing.html

--- a/test/controllers/employees_controller_test.rb
+++ b/test/controllers/employees_controller_test.rb
@@ -31,33 +31,33 @@ class EmployeesControllerTest < ActionDispatch::IntegrationTest
     }
   end
 
-  # test 'should get index' do
-  #   get /root
-  #   assert_response :success
-  #   assert_select 'h1', 'Employee Records'
-  #
-  #   # Checks to ensure we have 5 employee records
-  #   num_employee_records = 5
-  #   assert_select 'tr', num_employee_records
-  #
-  #   # Checks to ensure that we have 3 action
-  #   # links per employee record and the display
-  #   # value of each action
-  #   num_of_actions_on_employee_record = 3
-  #   num_of_action_links_for_employee_records = num_employee_records \
-  #                                              * \
-  #                                              num_of_actions_on_employee_record
-  #
-  #   assert_select 'tr td a', num_of_action_links_for_employee_records
-  #   assert_select 'tr td a', 'Show'
-  #   assert_select 'tr td a', 'Edit'
-  #   assert_select 'tr td a', 'Destroy'
-  #
-  #   # Checks the total number of links on
-  #   # page and the content of one of them
-  #   assert_select 'a', 16
-  #   assert_select 'a', 'Create Employee Record'
-  # end
+  test 'should get index' do
+    get employees_url
+    assert_response :success
+    assert_select 'h1', 'Employee Records'
+
+    # Checks to ensure we have 5 employee records
+    num_employee_records = 5
+    assert_select 'tr', num_employee_records
+
+    # Checks to ensure that we have 3 action
+    # links per employee record and the display
+    # value of each action
+    num_of_actions_on_employee_record = 3
+    num_of_action_links_for_employee_records = num_employee_records \
+                                               * \
+                                               num_of_actions_on_employee_record
+
+    assert_select 'tr td a', num_of_action_links_for_employee_records
+    assert_select 'tr td a', 'Show'
+    assert_select 'tr td a', 'Edit'
+    assert_select 'tr td a', 'Destroy'
+
+    # Checks the total number of links on
+    # page and the content of one of them
+    assert_select 'a', 16
+    assert_select 'a', 'Create Employee Record'
+  end
 
   test 'should get show' do
     get employee_url(@employee)

--- a/test/controllers/employees_controller_test.rb
+++ b/test/controllers/employees_controller_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'helpers/omniauth_login_test_helper'
 
 class EmployeesControllerTest < ActionDispatch::IntegrationTest
+  include OmniauthLoginTestHelper
+
   setup do
     @employee = employees :employee_name_valid
     @new_valid_employee = {

--- a/test/controllers/employees_controller_test.rb
+++ b/test/controllers/employees_controller_test.rb
@@ -32,6 +32,12 @@ class EmployeesControllerTest < ActionDispatch::IntegrationTest
       city: 'SmallVille',
       zip_code: '19910'
     }
+
+    # Login to application
+    # before running each test
+    provider = 'github'
+    user_name = 'Lex Luther'
+    login(provider, user_name)
   end
 
   test 'should get index' do

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -2,6 +2,14 @@ require 'test_helper'
 
 class SessionControllerTest < ActionDispatch::IntegrationTest
 
+  test 'should get login' do
+    get login_url
+    assert_response :success
+
+    notice = ''
+    test_login_page_content notice
+  end
+
   private
 
   def test_login_page_content(notice)

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -1,4 +1,12 @@
 require 'test_helper'
 
 class SessionControllerTest < ActionDispatch::IntegrationTest
+
+  private
+
+  def test_login_page_content(notice)
+    assert_select 'p', notice
+    assert_select 'h1', 'Employee Records Login'
+    assert_select 'a', 'Login with GitHub'
+  end
 end

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
+require 'helpers/omniauth_login_test_helper'
 
 class SessionControllerTest < ActionDispatch::IntegrationTest
+  include OmniauthLoginTestHelper
 
   test 'should get login' do
     get login_url
@@ -16,6 +18,14 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
 
     get login_url
     test_login_page_content 'Please login before proceeding'
+  end
+
+  test 'login successful by user' do
+    provider = 'github'
+    user_name = 'Lex Luther'
+    login provider, user_name
+
+    assert_redirected_to employees_url
   end
 
   private

--- a/test/controllers/session_controller_test.rb
+++ b/test/controllers/session_controller_test.rb
@@ -10,6 +10,14 @@ class SessionControllerTest < ActionDispatch::IntegrationTest
     test_login_page_content notice
   end
 
+  test 'redirect to login page no user logged in' do
+    get employees_url
+    assert_redirected_to login_url
+
+    get login_url
+    test_login_page_content 'Please login before proceeding'
+  end
+
   private
 
   def test_login_page_content(notice)

--- a/test/helpers/omniauth_login_test_helper.rb
+++ b/test/helpers/omniauth_login_test_helper.rb
@@ -1,2 +1,8 @@
 module OmniauthLoginTestHelper
+  private
+
+  def create_omniauth_mock_auth_hash(provider, user_name)
+    OmniAuth::AuthHash.new(provider: provider, uid: 12_345,
+                           info: { name: user_name })
+  end
 end

--- a/test/helpers/omniauth_login_test_helper.rb
+++ b/test/helpers/omniauth_login_test_helper.rb
@@ -1,6 +1,13 @@
 module OmniauthLoginTestHelper
   private
 
+  def login(provider, user_name)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:github] = create_omniauth_mock_auth_hash provider, user_name
+
+    get omniauth_callback_url(provider)
+  end
+
   def create_omniauth_mock_auth_hash(provider, user_name)
     OmniAuth::AuthHash.new(provider: provider, uid: 12_345,
                            info: { name: user_name })

--- a/test/helpers/omniauth_login_test_helper.rb
+++ b/test/helpers/omniauth_login_test_helper.rb
@@ -1,0 +1,2 @@
+module OmniauthLoginTestHelper
+end


### PR DESCRIPTION
- Create OmniauthLoginTestHelper to mock logging into the application in order to allow the tests in employees controller test to interact with the application and perform their tests

- Create tests for sessions controller pertaining to logging into the application